### PR TITLE
Unhide link to SoundCloud

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,8 +196,8 @@
               </button>
               <div class="flex-grow"></div>
             </div>
-            <aside ng-hide="true" class="mt4">
-              <a href="" class="mr2">Share</a>
+            <aside class="mt4">
+              <a href="" class="mr2" ng-hide="true">Share</a>
               <a ng-href="{{track.permalink_url}}">View on SoundCloud</a>
             </aside>
           </div>


### PR DESCRIPTION
Been looking for it to favourite some tracks!

Also, I think it's required by the [terms of their API](https://developers.soundcloud.com/docs/api/terms-of-use#branding):

> includes (in the case of web pages and mobile web pages) clearly visible backlinks from the relevant sounds within your app to the URL for the relevant sound on soundcloud.com (permalink_url).